### PR TITLE
Set API Specification to wip after Fall25

### DIFF
--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -88,7 +88,7 @@ externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/CustomerInsights
 servers:
-  - url: "{apiRoot}/customer-insights/v0.2"
+  - url: "{apiRoot}/customer-insights/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091


### PR DESCRIPTION
#### What type of PR is this?

* documentation
* subproject management



#### What this PR does / why we need it:

Set API Specification to wip after Fall25 metarelease


#### Which issue(s) this PR fixes:

Fixes #61 (partially)


#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
