### PR TITLE
Set Test Definitions to wip after Fall25

### DIFF
--- a/code/Test_definitions/customer-insights-retrieveScoring.feature
+++ b/code/Test_definitions/customer-insights-retrieveScoring.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Customer Insights API, v0.2.0 - Operation retrieveScoring
+Feature: CAMARA Customer Insights API, vwip - Operation retrieveScoring
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -10,7 +10,7 @@ Feature: CAMARA Customer Insights API, v0.2.0 - Operation retrieveScoring
   # References to OAS spec schemas refer to schemas specified in customer-insights.yaml
 
   Background: Common retrieveScoring setup
-    Given the resource "/customer-insights/v0.2/scoring/retrieve"
+    Given the resource "/customer-insights/vwip/scoring/retrieve"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

* documentation
* subproject management
* tests


#### What this PR does / why we need it:

Set Test Definitions to wip after Fall25 metarelease


#### Which issue(s) this PR fixes:

Fixes #61 (partially)


#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
