### PR TITLE
Plan Update for Release Candidate r3.1

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -10,31 +10,31 @@ repository:
   # Options: independent (default) | meta-release
   release_track: meta-release
   # Meta-release participation (update for next cycle when planning)
-  meta_release: Fall25
+  meta_release: Sync26
 
   # Target CAMARA release tag.
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r2.2
+  target_release_tag: r3.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.2
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: customer-insights
-    target_api_version: 0.2.0
-    target_api_status: public
+    target_api_version: 0.3.0
+    target_api_status: rc
     main_contacts:
       - PedroDiez
       - KevScarr


### PR DESCRIPTION
#### What type of PR is this?

* subproject management


#### What this PR does / why we need it:

This pull request updates the release planning configuration to move the project to release candidate (RC) status to be considered within Sync26 Metarelease.

Release plan updates:

- Updated `meta_release` in `release-plan.yaml` to `Sync26`
- Updated `target_release_tag` in `release-plan.yaml` to `r3.1`, indicating the start of a new release cycle.
- Updated `target_release_type` in `release-plan.yaml` to `pre-release-rc`
- Updated dependencies:
```md
dependencies:
  commonalities_release: r4.2
  identity_consent_management_release: r4.2
```
- Updated `target_api_version` to `0.3.0` in `release-plan.yaml`, reflecting the target API version
- Updated `target_api_status` to `rc` in `release-plan.yaml`


#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

To be merged after #70 


#### Changelog input

```
 Plan update for release candidate r3.1

```

#### Additional documentation 

This section can be blank.



```
docs

```
