### PR TITLE
Update API specification to local CAMARA_common.yaml references

### DIFF
--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -220,6 +220,7 @@ components:
       $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
   schemas:
     ScoringRequest:
+      descritption: Input parameters for the Scoring request, identifying the individual whose credit risk score is to be retrieved.
       type: object
       properties:
         idDocument:

--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -220,7 +220,7 @@ components:
       $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
   schemas:
     ScoringRequest:
-      descritption: Input parameters for the Scoring request, identifying the individual whose credit risk score is to be retrieved.
+      description: Input parameters for the Scoring request, identifying the individual whose credit risk score is to be retrieved.
       type: object
       properties:
         idDocument:

--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -116,7 +116,7 @@ servers:
     variables:
       apiRoot:
         default: http://localhost:9091
-        description: API root, defined by the service provider
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
   - name: Scoring
     description: Operations to retrieve Scoring information.
@@ -135,7 +135,7 @@ paths:
         It also allows to select the type of the Scoring scale measurement.
       operationId: retrieveScoring
       parameters:
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       requestBody:
         required: true
         content:
@@ -196,7 +196,7 @@ paths:
           description: Scoring result.
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -215,48 +215,25 @@ paths:
                     scoringType: veritasIndex
                     scoringValue: 4
         "400":
-          $ref: "#/components/responses/Generic400"
+          $ref: "#/components/responses/InvalidArgument400"
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "422":
-          $ref: "#/components/responses/Generic422"
+          $ref: "#/components/responses/UnprocessableContent422"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: "#/components/responses/RequestLimitReached429"
 components:
   securitySchemes:
     openId:
-      type: openIdConnect
-      openIdConnectUrl: https://example.com/.well-known/openid-configuration
-  headers:
-    x-correlator:
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
-  parameters:
-    x-correlator:
-      name: x-correlator
-      in: header
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
   schemas:
-    XCorrelator:
-      type: string
-      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      maxLength: 256
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-    PhoneNumber:
-      type: string
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
-      pattern: '^\+[1-9][0-9]{4,14}$'
-      maxLength: 16
-      example: "+123456789"
     ScoringRequest:
       type: object
+      description: Input parameters for the Scoring request, identifying the individual whose credit risk score is to be retrieved.
       properties:
         idDocument:
           type: string
@@ -264,7 +241,7 @@ components:
             Identification number associated to the official identity document in the country. It may contain alphanumeric characters.
           maxLength: 30
         phoneNumber:
-          $ref: "#/components/schemas/PhoneNumber"
+          $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
         scoringType:
           type: string
           description: |-
@@ -280,6 +257,17 @@ components:
     ScoringResponse:
       type: object
       description: Scoring information based on the individual's profile owned by a Telco Operator.
+      oneOf:
+        - $ref: "#/components/schemas/GaugeMetricResponse"
+        - $ref: "#/components/schemas/VeritasIndexResponse"
+      discriminator:
+        propertyName: scoringType
+        mapping:
+          gaugeMetric: "#/components/schemas/GaugeMetricResponse"
+          veritasIndex: "#/components/schemas/VeritasIndexResponse"
+    GaugeMetricResponse:
+      type: object
+      description: Scoring information with Gauge Metric scale based on the individual's profile owned by a Telco Operator.
       required:
         - scoringType
         - scoringValue
@@ -289,56 +277,48 @@ components:
           description: |-
             Scoring measurement system.
 
-            Allowed values are:
-
-            * `gaugeMetric`: ranges from index 850 (lowest risk) to index 300 (highest risk)
-            * `veritasIndex`: ranges from index 0 (lowest risk) to index 19 (highest risk)
+            `gaugeMetric`: ranges from index 850 (lowest risk) to index 300 (highest risk)
           enum:
             - gaugeMetric
+        scoringValue:
+          type: integer
+          description: Result of the Scoring analysis using Gauge Metric scale (300-850).
+          format: int32
+          minimum: 300
+          maximum: 850
+    VeritasIndexResponse:
+      type: object
+      description: Scoring information with Veritas Index scale based on the individual's profile owned by a Telco Operator.
+      required:
+        - scoringType
+        - scoringValue
+      properties:
+        scoringType:
+          type: string
+          description: |-
+            Scoring measurement system.
+
+            `veritasIndex`: ranges from index 0 (lowest risk) to index 19 (highest risk)
+          enum:
             - veritasIndex
         scoringValue:
           type: integer
-          description: Result of the Scoring analysis expressed in the measure indicated in the `scoringType` field.
+          description: Result of the Scoring analysis using Veritas Index scale (0-19).
           format: int32
-          oneOf:
-            - minimum: 0
-              maximum: 19
-            - minimum: 300
-              maximum: 850
-    ErrorInfo:
-      type: object
-      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
-      required:
-        - status
-        - code
-        - message
-      properties:
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 599
-          description: HTTP response status code
-        code:
-          type: string
-          maxLength: 96
-          description: A human-readable code to describe the error
-        message:
-          type: string
-          maxLength: 512
-          description: A human-readable description of what the event represents
+          minimum: 0
+          maximum: 19
   responses:
-    Generic400:
+    InvalidArgument400:
       description: |-
         Problem with the client request.
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -354,41 +334,16 @@ components:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param
-    Generic401:
-      description: Unauthorized
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 401
-                  code:
-                    enum:
-                      - UNAUTHENTICATED
-          examples:
-            GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated and a new authentication is required
-              value:
-                status: 401
-                code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
-    Generic403:
+    PermissionDenied403:
       description: Forbidden
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -404,43 +359,7 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-    Generic404:
-      description: |-
-        Not found
-
-        In addition to regular NOT_FOUND scenario, another scenarios may exist:
-        - Phone Number not found ("code": "IDENTIFIER_NOT_FOUND","message": "phoneNumber not found.").
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 404
-                  code:
-                    enum:
-                      - NOT_FOUND
-                      - IDENTIFIER_NOT_FOUND
-          examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
-            GENERIC_404_IDENTIFIER_NOT_FOUND:
-              description: Some identifier cannot be matched to a device. In this API it refers to a phoneNumber.
-              value:
-                status: 404
-                code: IDENTIFIER_NOT_FOUND
-                message: phoneNumber not found.
-    Generic422:
+    UnprocessableContent422:
       description: |-
         Unprocessable Content
 
@@ -452,12 +371,12 @@ components:
         - Provided `idDocument` field is not supported. (`"code": "CUSTOMER_INSIGHTS.ID_DOCUMENT_NOT_SUPPORTED","message": "Indicated parameter idDocument is not supported"`)
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -501,16 +420,16 @@ components:
                 status: 422
                 code: CUSTOMER_INSIGHTS.ID_DOCUMENT_NOT_SUPPORTED
                 message: Indicated parameter `idDocument` is not supported.
-    Generic429:
+    RequestLimitReached429:
       description: Too Many Requests
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:

--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -123,7 +123,7 @@ paths:
         It also allows to select the type of the Scoring scale measurement.
       operationId: retrieveScoring
       parameters:
-        - $ref: "#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       requestBody:
         required: true
         content:
@@ -184,7 +184,7 @@ paths:
           description: Scoring result.
           headers:
             x-correlator:
-              $ref: "#/components/headers/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -203,46 +203,22 @@ paths:
                     scoringType: veritasIndex
                     scoringValue: 4
         "400":
-          $ref: "#/components/responses/Generic400"
+          $ref: "#/components/responses/InvalidArgument400"
         "401":
-          $ref: "#/components/responses/Generic401"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/PermissionDenied403"
         "404":
-          $ref: "#/components/responses/Generic404"
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
         "422":
-          $ref: "#/components/responses/Generic422"
+          $ref: "#/components/responses/UnprocessableContent422"
         "429":
-          $ref: "#/components/responses/Generic429"
+          $ref: "#/components/responses/RequestLimitReached429"
 components:
   securitySchemes:
     openId:
-      type: openIdConnect
-      openIdConnectUrl: https://example.com/.well-known/openid-configuration
-  headers:
-    x-correlator:
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
-  parameters:
-    x-correlator:
-      name: x-correlator
-      in: header
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
+      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
   schemas:
-    XCorrelator:
-      type: string
-      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      maxLength: 256
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-    PhoneNumber:
-      type: string
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
-      pattern: '^\+[1-9][0-9]{4,14}$'
-      maxLength: 16
-      example: "+123456789"
     ScoringRequest:
       type: object
       properties:
@@ -252,7 +228,7 @@ components:
             Identification number associated to the official identity document in the country. It may contain alphanumeric characters.
           maxLength: 30
         phoneNumber:
-          $ref: "#/components/schemas/PhoneNumber"
+          $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
         scoringType:
           type: string
           description: |-
@@ -293,40 +269,18 @@ components:
               maximum: 19
             - minimum: 300
               maximum: 850
-    ErrorInfo:
-      type: object
-      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
-      required:
-        - status
-        - code
-        - message
-      properties:
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 599
-          description: HTTP response status code
-        code:
-          type: string
-          maxLength: 96
-          description: A human-readable code to describe the error
-        message:
-          type: string
-          maxLength: 512
-          description: A human-readable description of what the event represents
   responses:
-    Generic400:
+    InvalidArgument400:
       description: |-
         Problem with the client request.
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -336,47 +290,22 @@ components:
                     enum:
                       - INVALID_ARGUMENT
           examples:
-            InvalidArgument:
+            GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
               value:
                 status: 400
                 code: INVALID_ARGUMENT
-                message: Client specified an invalid argument, request body or query param
-    Generic401:
-      description: Unauthorized
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 401
-                  code:
-                    enum:
-                      - UNAUTHENTICATED
-          examples:
-            GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated and a new authentication is required
-              value:
-                status: 401
-                code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
-    Generic403:
+                message: Client specified an invalid argument, request body or query param.
+    PermissionDenied403:
       description: Forbidden
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -392,43 +321,7 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-    Generic404:
-      description: |-
-        Not found
-
-        In addition to regular NOT_FOUND scenario, another scenarios may exist:
-        - Phone Number not found ("code": "IDENTIFIER_NOT_FOUND","message": "phoneNumber not found.").
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 404
-                  code:
-                    enum:
-                      - NOT_FOUND
-                      - IDENTIFIER_NOT_FOUND
-          examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
-            GENERIC_404_IDENTIFIER_NOT_FOUND:
-              description: Some identifier cannot be matched to a device. In this API it refers to a phoneNumber.
-              value:
-                status: 404
-                code: IDENTIFIER_NOT_FOUND
-                message: phoneNumber not found.
-    Generic422:
+    UnprocessableContent422:
       description: |-
         Unprocessable Content
 
@@ -440,12 +333,12 @@ components:
         - Provided `idDocument` field is not supported. (`"code": "CUSTOMER_INSIGHTS.ID_DOCUMENT_NOT_SUPPORTED","message": "Indicated parameter idDocument is not supported"`)
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -489,16 +382,16 @@ components:
                 status: 422
                 code: CUSTOMER_INSIGHTS.ID_DOCUMENT_NOT_SUPPORTED
                 message: Indicated parameter `idDocument` is not supported.
-    Generic429:
+    RequestLimitReached429:
       description: Too Many Requests
       headers:
         x-correlator:
-          $ref: "#/components/headers/x-correlator"
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:

--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -243,6 +243,7 @@ components:
             - gaugeMetric
             - veritasIndex
     ScoringResponse:
+      description: Scoring information based on the individual's profile owned by a Telco Operator.
       oneOf:
         - $ref: "#/components/schemas/GaugeMetricResponse"
         - $ref: "#/components/schemas/VeritasIndexResponse"

--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -242,8 +242,17 @@ components:
             - gaugeMetric
             - veritasIndex
     ScoringResponse:
+      oneOf:
+        - $ref: "#/components/schemas/GaugeMetricResponse"
+        - $ref: "#/components/schemas/VeritasIndexResponse"
+      discriminator:
+        propertyName: scoringType
+        mapping:
+          gaugeMetric: "#/components/schemas/GaugeMetricResponse"
+          veritasIndex: "#/components/schemas/VeritasIndexResponse"
+    GaugeMetricResponse:
       type: object
-      description: Scoring information based on the individual's profile owned by a Telco Operator.
+      description: Scoring information with Gauge Metric scale based on the individual's profile owned by a Telco Operator.
       required:
         - scoringType
         - scoringValue
@@ -253,22 +262,36 @@ components:
           description: |-
             Scoring measurement system.
 
-            Allowed values are:
-
-            * `gaugeMetric`: ranges from index 850 (lowest risk) to index 300 (highest risk)
-            * `veritasIndex`: ranges from index 0 (lowest risk) to index 19 (highest risk)
+            `gaugeMetric`: ranges from index 850 (lowest risk) to index 300 (highest risk)
           enum:
             - gaugeMetric
+        scoringValue:
+          type: integer
+          description: Result of the Scoring analysis using Gauge Metric scale (300-850).
+          format: int32
+          minimum: 300
+          maximum: 850
+    VeritasIndexResponse:
+      type: object
+      description: Scoring information with Veritas Index scale based on the individual's profile owned by a Telco Operator.
+      required:
+        - scoringType
+        - scoringValue
+      properties:
+        scoringType:
+          type: string
+          description: |-
+            Scoring measurement system.
+
+            `veritasIndex`: ranges from index 0 (lowest risk) to index 19 (highest risk)
+          enum:
             - veritasIndex
         scoringValue:
           type: integer
-          description: Result of the Scoring analysis expressed in the measure indicated in the `scoringType` field.
+          description: Result of the Scoring analysis using Veritas Index scale (0-19).
           format: int32
-          oneOf:
-            - minimum: 0
-              maximum: 19
-            - minimum: 300
-              maximum: 850
+          minimum: 0
+          maximum: 19
   responses:
     InvalidArgument400:
       description: |-

--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -45,6 +45,7 @@ info:
 
       - An operation to retrieve Scoring information.
 
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -52,7 +53,9 @@ info:
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
+    <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:BEGIN -->
     # Identifying the phone number from the access token
 
     This API requires the API consumer to identify a phone number as the subject of the API as follows:
@@ -66,6 +69,7 @@ info:
     - If the subject cannot be identified from the access token and the optional `phoneNumber` field is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
 
     - If the subject can be identified from the access token and the optional `phoneNumber` field is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same phone number is identified by these two methods, as the server is unable to make this comparison.
+    <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:END -->
 
     # Additional Information on Error scenarios
 
@@ -79,13 +83,21 @@ info:
       - The API is invoked without `idDocument` and the field is required by the API Provider.
       - The API is invoked with a combination of `phoneNumber` and `idDocument`, considering `idDocument` is required by the API Provider, that does not point to the same subscription (i.e. the `phoneNumber` and `idDocument` provided are not related).
 
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
 
-    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
+
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+    # Request body strictness
+
+    This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
     # Further info and support
 
@@ -104,7 +116,7 @@ servers:
     variables:
       apiRoot:
         default: http://localhost:9091
-        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
+        description: API root, defined by the service provider
 tags:
   - name: Scoring
     description: Operations to retrieve Scoring information.
@@ -123,7 +135,7 @@ paths:
         It also allows to select the type of the Scoring scale measurement.
       operationId: retrieveScoring
       parameters:
-        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+        - $ref: "#/components/parameters/x-correlator"
       requestBody:
         required: true
         content:
@@ -184,7 +196,7 @@ paths:
           description: Scoring result.
           headers:
             x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+              $ref: "#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -203,24 +215,47 @@ paths:
                     scoringType: veritasIndex
                     scoringValue: 4
         "400":
-          $ref: "#/components/responses/InvalidArgument400"
+          $ref: "#/components/responses/Generic400"
         "401":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
+          $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/PermissionDenied403"
+          $ref: "#/components/responses/Generic403"
         "404":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
+          $ref: "#/components/responses/Generic404"
         "422":
-          $ref: "#/components/responses/UnprocessableContent422"
+          $ref: "#/components/responses/Generic422"
         "429":
-          $ref: "#/components/responses/RequestLimitReached429"
+          $ref: "#/components/responses/Generic429"
 components:
   securitySchemes:
     openId:
-      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+  headers:
+    x-correlator:
+      description: Correlation id for the different services
+      schema:
+        $ref: "#/components/schemas/XCorrelator"
+  parameters:
+    x-correlator:
+      name: x-correlator
+      in: header
+      description: Correlation id for the different services
+      schema:
+        $ref: "#/components/schemas/XCorrelator"
   schemas:
+    XCorrelator:
+      type: string
+      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
+      maxLength: 256
+      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
+    PhoneNumber:
+      type: string
+      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
+      pattern: '^\+[1-9][0-9]{4,14}$'
+      maxLength: 16
+      example: "+123456789"
     ScoringRequest:
-      description: Input parameters for the Scoring request, identifying the individual whose credit risk score is to be retrieved.
       type: object
       properties:
         idDocument:
@@ -229,7 +264,7 @@ components:
             Identification number associated to the official identity document in the country. It may contain alphanumeric characters.
           maxLength: 30
         phoneNumber:
-          $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
+          $ref: "#/components/schemas/PhoneNumber"
         scoringType:
           type: string
           description: |-
@@ -243,18 +278,8 @@ components:
             - gaugeMetric
             - veritasIndex
     ScoringResponse:
-      description: Scoring information based on the individual's profile owned by a Telco Operator.
-      oneOf:
-        - $ref: "#/components/schemas/GaugeMetricResponse"
-        - $ref: "#/components/schemas/VeritasIndexResponse"
-      discriminator:
-        propertyName: scoringType
-        mapping:
-          gaugeMetric: "#/components/schemas/GaugeMetricResponse"
-          veritasIndex: "#/components/schemas/VeritasIndexResponse"
-    GaugeMetricResponse:
       type: object
-      description: Scoring information with Gauge Metric scale based on the individual's profile owned by a Telco Operator.
+      description: Scoring information based on the individual's profile owned by a Telco Operator.
       required:
         - scoringType
         - scoringValue
@@ -264,48 +289,56 @@ components:
           description: |-
             Scoring measurement system.
 
-            `gaugeMetric`: ranges from index 850 (lowest risk) to index 300 (highest risk)
+            Allowed values are:
+
+            * `gaugeMetric`: ranges from index 850 (lowest risk) to index 300 (highest risk)
+            * `veritasIndex`: ranges from index 0 (lowest risk) to index 19 (highest risk)
           enum:
             - gaugeMetric
-        scoringValue:
-          type: integer
-          description: Result of the Scoring analysis using Gauge Metric scale (300-850).
-          format: int32
-          minimum: 300
-          maximum: 850
-    VeritasIndexResponse:
-      type: object
-      description: Scoring information with Veritas Index scale based on the individual's profile owned by a Telco Operator.
-      required:
-        - scoringType
-        - scoringValue
-      properties:
-        scoringType:
-          type: string
-          description: |-
-            Scoring measurement system.
-
-            `veritasIndex`: ranges from index 0 (lowest risk) to index 19 (highest risk)
-          enum:
             - veritasIndex
         scoringValue:
           type: integer
-          description: Result of the Scoring analysis using Veritas Index scale (0-19).
+          description: Result of the Scoring analysis expressed in the measure indicated in the `scoringType` field.
           format: int32
-          minimum: 0
-          maximum: 19
+          oneOf:
+            - minimum: 0
+              maximum: 19
+            - minimum: 300
+              maximum: 850
+    ErrorInfo:
+      type: object
+      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
+      required:
+        - status
+        - code
+        - message
+      properties:
+        status:
+          type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
+          description: HTTP response status code
+        code:
+          type: string
+          maxLength: 96
+          description: A human-readable code to describe the error
+        message:
+          type: string
+          maxLength: 512
+          description: A human-readable description of what the event represents
   responses:
-    InvalidArgument400:
+    Generic400:
       description: |-
         Problem with the client request.
       headers:
         x-correlator:
-          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+          $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - $ref: "#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -315,22 +348,47 @@ components:
                     enum:
                       - INVALID_ARGUMENT
           examples:
-            GENERIC_400_INVALID_ARGUMENT:
+            InvalidArgument:
               description: Invalid Argument. Generic Syntax Exception
               value:
                 status: 400
                 code: INVALID_ARGUMENT
-                message: Client specified an invalid argument, request body or query param.
-    PermissionDenied403:
-      description: Forbidden
+                message: Client specified an invalid argument, request body or query param
+    Generic401:
+      description: Unauthorized
       headers:
         x-correlator:
-          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+          $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 401
+                  code:
+                    enum:
+                      - UNAUTHENTICATED
+          examples:
+            GENERIC_401_UNAUTHENTICATED:
+              description: Request cannot be authenticated and a new authentication is required
+              value:
+                status: 401
+                code: UNAUTHENTICATED
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
+    Generic403:
+      description: Forbidden
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -346,7 +404,43 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-    UnprocessableContent422:
+    Generic404:
+      description: |-
+        Not found
+
+        In addition to regular NOT_FOUND scenario, another scenarios may exist:
+        - Phone Number not found ("code": "IDENTIFIER_NOT_FOUND","message": "phoneNumber not found.").
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
+            GENERIC_404_IDENTIFIER_NOT_FOUND:
+              description: Some identifier cannot be matched to a device. In this API it refers to a phoneNumber.
+              value:
+                status: 404
+                code: IDENTIFIER_NOT_FOUND
+                message: phoneNumber not found.
+    Generic422:
       description: |-
         Unprocessable Content
 
@@ -358,12 +452,12 @@ components:
         - Provided `idDocument` field is not supported. (`"code": "CUSTOMER_INSIGHTS.ID_DOCUMENT_NOT_SUPPORTED","message": "Indicated parameter idDocument is not supported"`)
       headers:
         x-correlator:
-          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+          $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - $ref: "#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -407,16 +501,16 @@ components:
                 status: 422
                 code: CUSTOMER_INSIGHTS.ID_DOCUMENT_NOT_SUPPORTED
                 message: Indicated parameter `idDocument` is not supported.
-    RequestLimitReached429:
+    Generic429:
       description: Too Many Requests
       headers:
         x-correlator:
-          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+          $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - $ref: "#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:

--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -104,7 +104,7 @@ servers:
     variables:
       apiRoot:
         default: http://localhost:9091
-        description: API root, defined by the service provider
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
   - name: Scoring
     description: Operations to retrieve Scoring information.


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature
* subproject management


#### What this PR does / why we need it:

This PR adapts API Specification to update references (where applicable) to `CAMARA_common.yaml` (local copy generated by Release Automation process by means of PR #72).

Approach followed is based on [sample-service.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/api-templates/sample-service.yaml).

Changes summary:
- Update reference for `x-correlator` both for headers and parameters cases, pointing lo local `CAMARA_common.yaml`
- Update reference for `openId`, pointing to local `CAMARA_common.yaml`
- Update reference for `phoneNumber`, pointing to local `CAMARA_common.yaml`
- Removal of `headers` and `parameters` from `components`
- Removal of `XCorrelator`, `PhoneNumber` and `ErrorInfo` from `components/schemas`
- ErrorResponses:
  - `401` and `404` pointing lo local `CAMARA_common.yaml`
  - For the rest of errors keeping local schema (renaming it to not collide with `CAMARA_common.yaml` one, referencing internally to `CAMARA_common.yaml` where applicable (`x-correlator`, `ErrorInfo`)
- Also aligment with Commonalities r4.3 is covered (`info.description` templates wording updated)

Some additional comments in for PR evaluation in `Special notes for reviewers` section


#### Which issue(s) this PR fixes:

Fixes #69 

#### Special notes for reviewers:

As it can be seen, `x-correlator` and `ErrorInfo` references are updates several times. 
Question if it is better or makes sense to keep local `x-correlator` and `ErrorInfo` local schemas definition and only point once that schema definition to local `CAMARA_common.yaml`, so the rest of API specification remains unchanged. That is:

(Line 222)
```yaml 
  headers:
    x-correlator:
       $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
```

(Line 227)
```yaml
  parameters:
    x-correlator:
      $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
```

(Line 296)
```yaml
  ErrorInfo:
    $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
```

@rartych, @hdamker your view on this point is highly appreciated.


#### Changelog input

```
 API specification update to local CAMARA_common.yaml references

```

#### Additional documentation 

This section can be blank.



```
docs

```
