### PR TITLE
Plan Update for Release Candidate r3.1 (Refreshed)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.2
+  commonalities_release: r4.3
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
#### What type of PR is this?

* subproject management


#### What this PR does / why we need it:

This pull request updates the release planning configuration to move the project to release candidate (RC) status to be considered within Sync26 Metarelease. 

It reflects an update from PR #68. WG has agreed to generate Release Candidate considering Public release of Commonalities for Spring26: https://github.com/camaraproject/Commonalities/releases/tag/r4.3  

Release plan updates:

- Updated dependencies:
```md
dependencies:
  commonalities_release: r4.3
```


#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:



#### Changelog input

```
  Plan update for release candidate r3.1 (final)

```

#### Additional documentation 

This section can be blank.



```
docs

```
