### PR TITLE
idDocument description improvement

### DIFF
--- a/code/API_definitions/customer-insights.yaml
+++ b/code/API_definitions/customer-insights.yaml
@@ -35,6 +35,8 @@ info:
                   16-17    C
                   18-19    DDD
 
+    * **idDocument**: identification number of the official identity document associated with the individual in the country (e.g. national ID card, tax identification number, or equivalent), used as an alternative or complementary identifier to `phoneNumber` to determine the subscriber whose Scoring is being requested.
+
     # API Functionality
 
     This API allows to retrieve the Scoring information of a user within the operator.


### PR DESCRIPTION
#### What type of PR is this?

* documentation


#### What this PR does / why we need it:

This PR adds `idDocument` definition in `info.description`
- Added `idDocument` definition to the "Relevant Definitions and concepts" section of `info.description`, explaining it's an identity-document number used as an alternative/complementary identifier to `phoneNumber`.

Background comes from Release Management review of first Customer Insights release Candidate for Sync26


#### Which issue(s) this PR fixes:

Fixes #88 

#### Special notes for reviewers:



#### Changelog input

```
`idDocument` concept added in API `info.description`

```

#### Additional documentation 

This section can be blank.



```
docs

```
